### PR TITLE
Updated CLIView.printPlayerScores() to correctly sort the player rankings

### DIFF
--- a/src/csc439teamplatypus/cardgame/golfgame/CLIView.java
+++ b/src/csc439teamplatypus/cardgame/golfgame/CLIView.java
@@ -243,7 +243,7 @@ public class CLIView extends View {
 
                     temp = playerRank[j];
                     playerRank[j] = playerRank[i];
-                    playerRank[i] = playerRank[j];
+                    playerRank[i] = temp;
                 }
 
         System.out.println("Scoreboard: Hole " + (getNumberOfPlayedHoles() + 1)


### PR DESCRIPTION
When swapping the two player rankings being compared, I used the wrong variable at one point. Now corrected